### PR TITLE
Fix compat with pyYAML < 5

### DIFF
--- a/pytsn/config.py
+++ b/pytsn/config.py
@@ -154,7 +154,7 @@ def normalise_cbs(ifname: str, config: dict) -> dict:
 
 def read_config(config_path: str):
     with open(config_path) as f:
-        config = yaml.load(f, Loader=yaml.FullLoader)
+        config = yaml.safe_load(f)
 
     for ifname, ifconfig in config['nics'].items():
         if 'tas' in ifconfig:


### PR DESCRIPTION
Debian's default python3-yaml package is way too old (3.13 vs 5.4.1)
this commit will provide compatibility.