### PR TITLE
hotfix vlan name

### DIFF
--- a/src/vlan.rs
+++ b/src/vlan.rs
@@ -125,8 +125,8 @@ pub fn delete_vlan(ifname: &str, vlanid: u16) -> Result<i32, String> {
 }
 
 pub fn get_vlan_name(ifname: &str, vlanid: u16) -> String {
-    if ifname.len() > 10 {
-        format!("{}.{}", &ifname[..10], vlanid)
+    if ifname.len() > 9 {
+        format!("{}.{}", &ifname[..9], vlanid)
     } else {
         format!("{}.{}", &ifname, vlanid)
     }


### PR DESCRIPTION
occur bug after 2cec0468ee03174efa74cebfde8adfb4dd1233e5 commit.
sock_open return vlan name, but other functions get ifname and vlan id both.
Example, sock_open return enp1s0np2.10. And other functions get parameter that ifname is enp1s0np2.10, vlan_id is 10.
When other functions call get_vlan_name(), get enp1s0np2..10 to vlan name.
So, functions parameter need to change vlan_name instead of ifname and vlan_id. 
But little complicated, so changed simplify for now.