### PR TITLE
Revert "fix sock_open return vlan name instead of interface name"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub fn sock_open(
 
     Ok(TsnSocket {
         fd: sock,
-        ifname: name,
+        ifname: ifname.to_string(),
         vlanid,
     })
 }


### PR DESCRIPTION
Reverts tsnlab/libtsn#32
`TsnSocket.ifname` should contain original interface name, So it should be used later on `sock_close` → `delete_vlan`

https://github.com/tsnlab/libtsn/blob/9426f75814fe95d93bb0a0deb20b952406e28474/src/lib.rs#L180-L181

https://github.com/tsnlab/libtsn/blob/9426f75814fe95d93bb0a0deb20b952406e28474/src/lib.rs#L80-L104

Also close #34 