### PR TITLE
Add RPi5 support

### DIFF
--- a/driver/XDMA/linux-kernel/xdma/Makefile
+++ b/driver/XDMA/linux-kernel/xdma/Makefile
@@ -20,13 +20,15 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
+uname_m := $(shell uname -m)
+
 EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
-ifneq ($(findstring rpi,$(shell uname -r)),)
+ifeq ($(uname_m),x86_64)
+	EXTRA_CFLAGS += -msse2
+else
 	EXTRA_CFLAGS += -march=armv8-a+simd -D__LIBXDMA_RPI__
 	KBUILD_CFLAGS := $(filter-out -mgeneral-regs-only, $(KBUILD_CFLAGS))
 	KBUILD_CFLAGS += -ffreestanding -isystem $(shell $(CC) -print-file-name=include)
-else
-	EXTRA_CFLAGS += -msse2
 endif
 
 ifeq ($(DEBUG),1)

--- a/driver/XDMA/linux-kernel/xdma/Makefile
+++ b/driver/XDMA/linux-kernel/xdma/Makefile
@@ -22,7 +22,7 @@ TARGET_MODULE:=xdma
 
 EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
 ifneq ($(findstring rpi,$(shell uname -r)),)
-	EXTRA_CFLAGS += -march=armv8-a+simd
+	EXTRA_CFLAGS += -march=armv8-a+simd -D__LIBXDMA_RPI__
 	KBUILD_CFLAGS := $(filter-out -mgeneral-regs-only, $(KBUILD_CFLAGS))
 	KBUILD_CFLAGS += -ffreestanding -isystem $(shell $(CC) -print-file-name=include)
 else

--- a/driver/XDMA/linux-kernel/xdma/Makefile
+++ b/driver/XDMA/linux-kernel/xdma/Makefile
@@ -20,7 +20,7 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS) -march=armv8-a+simd -mcpu=cortex-a76+crc+crypto
+EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS) -march=armv8-a+simd
 ifeq ($(DEBUG),1)
 	EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
 endif

--- a/driver/XDMA/linux-kernel/xdma/Makefile
+++ b/driver/XDMA/linux-kernel/xdma/Makefile
@@ -20,7 +20,7 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS) -msse2
+EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS) -march=armv8-a+simd -mcpu=cortex-a76+crc+crypto
 ifeq ($(DEBUG),1)
 	EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
 endif
@@ -28,6 +28,9 @@ ifneq ($(config_bar_num),)
 	EXTRA_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
 endif
 #EXTRA_CFLAGS += -DINTERNAL_TESTING
+
+KBUILD_CFLAGS := $(filter-out -mgeneral-regs-only, $(KBUILD_CFLAGS))
+KBUILD_CFLAGS += -ffreestanding -isystem $(shell $(CC) -print-file-name=include)
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o xdma_netdev.o alinx_ptp.o alinx_arch.o tsn.o

--- a/driver/XDMA/linux-kernel/xdma/Makefile
+++ b/driver/XDMA/linux-kernel/xdma/Makefile
@@ -20,7 +20,15 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS) -march=armv8-a+simd
+EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
+ifneq ($(findstring rpi,$(shell uname -r)),)
+	EXTRA_CFLAGS += -march=armv8-a+simd
+	KBUILD_CFLAGS := $(filter-out -mgeneral-regs-only, $(KBUILD_CFLAGS))
+	KBUILD_CFLAGS += -ffreestanding -isystem $(shell $(CC) -print-file-name=include)
+else
+	EXTRA_CFLAGS += -msse2
+endif
+
 ifeq ($(DEBUG),1)
 	EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
 endif
@@ -28,9 +36,6 @@ ifneq ($(config_bar_num),)
 	EXTRA_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
 endif
 #EXTRA_CFLAGS += -DINTERNAL_TESTING
-
-KBUILD_CFLAGS := $(filter-out -mgeneral-regs-only, $(KBUILD_CFLAGS))
-KBUILD_CFLAGS += -ffreestanding -isystem $(shell $(CC) -print-file-name=include)
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o xdma_netdev.o alinx_ptp.o alinx_arch.o tsn.o

--- a/driver/XDMA/linux-kernel/xdma/alinx_ptp.c
+++ b/driver/XDMA/linux-kernel/xdma/alinx_ptp.c
@@ -224,7 +224,7 @@ exit:
         return 0;
 }
 
-struct ptp_clock_info ptp_clock_info_init(void) {
+static struct ptp_clock_info ptp_clock_info_init(void) {
         struct ptp_clock_info info = {
                 .owner = THIS_MODULE,
                 .name = "ptp",

--- a/driver/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -256,8 +256,14 @@ static int xdma_ethtool_get_ts_info(struct net_device * ndev, struct ethtool_ts_
 	return 0;
 }
 
+static int xdma_ethtool_get_link_ksettings(struct net_device *netdev, struct ethtool_link_ksettings *cmd) {
+	cmd->base.speed = 1000;
+	return 0;
+}
+
 static const struct ethtool_ops xdma_ethtool_ops = {
 	.get_ts_info = xdma_ethtool_get_ts_info,
+	.get_link_ksettings = xdma_ethtool_get_link_ksettings,
 };
 
 static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)

--- a/driver/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -257,6 +257,7 @@ static int xdma_ethtool_get_ts_info(struct net_device * ndev, struct ethtool_ts_
 }
 
 static int xdma_ethtool_get_link_ksettings(struct net_device *netdev, struct ethtool_link_ksettings *cmd) {
+	/* TODO: PHY also supports 100Mbps */
 	cmd->base.speed = 1000;
 	return 0;
 }

--- a/driver/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -426,8 +426,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	/* Set the MAC address */
 	get_mac_address(mac_addr, xdev);
-	memcpy(ndev->dev_addr, mac_addr, ETH_ALEN);
-	memcpy(ndev->dev_addr_shadow, mac_addr, ETH_ALEN);
+	dev_addr_set(ndev, mac_addr);
 
 	priv->rx_buffer = dma_alloc_coherent(&pdev->dev, XDMA_BUFFER_SIZE, &priv->rx_dma_addr, GFP_KERNEL);
 	if (!priv->rx_buffer) {

--- a/driver/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -414,7 +414,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	}
 
 	priv->res = dma_alloc_coherent(&pdev->dev, sizeof(struct xdma_result), &priv->res_dma_addr, GFP_KERNEL);
-	if (unlikely(dma_mapping_error(&pdev->dev, priv->res))) {
+	if (!priv->res) {
 		pr_err("res dma_alloc_coherent failed\n");
 		free_netdev(ndev);
 		rv = -ENOMEM;
@@ -430,7 +430,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	memcpy(ndev->dev_addr_shadow, mac_addr, ETH_ALEN);
 
 	priv->rx_buffer = dma_alloc_coherent(&pdev->dev, XDMA_BUFFER_SIZE, &priv->rx_dma_addr, GFP_KERNEL);
-	if (unlikely(dma_mapping_error(&pdev->dev, priv->rx_buffer))) {
+	if (!priv->rx_buffer) {
 		pr_err("buffer dma_alloc_coherent failed\n");
 		free_netdev(ndev);
 		rv = -ENOMEM;

--- a/driver/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -228,7 +228,11 @@ static const struct net_device_ops xdma_netdev_ops = {
 	.ndo_eth_ioctl = xdma_netdev_ioctl,
 };
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static int xdma_ethtool_get_ts_info(struct net_device * ndev, struct kernel_ethtool_ts_info * info) {
+#else
 static int xdma_ethtool_get_ts_info(struct net_device * ndev, struct ethtool_ts_info * info) {
+#endif
 	struct xdma_private *priv = netdev_priv(ndev);
 	struct xdma_pci_dev *xpdev = dev_get_drvdata(&priv->pdev->dev);
 
@@ -417,6 +421,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	/* Set the MAC address */
 	get_mac_address(mac_addr, xdev);
 	memcpy(ndev->dev_addr, mac_addr, ETH_ALEN);
+	memcpy(ndev->dev_addr_shadow, mac_addr, ETH_ALEN);
 
 	priv->rx_buffer = kmalloc(XDMA_BUFFER_SIZE, GFP_KERNEL);
 	if (!priv->rx_buffer) {

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -52,7 +52,6 @@ void rx_desc_set(struct xdma_desc *desc, dma_addr_t addr, u32 len)
 int xdma_netdev_open(struct net_device *ndev)
 {
         struct xdma_private *priv = netdev_priv(ndev);
-        dma_addr_t dma_addr;
         u32 lo, hi;
         unsigned long flag;
 
@@ -60,13 +59,8 @@ int xdma_netdev_open(struct net_device *ndev)
         netif_start_queue(ndev);
 
         /* Set the RX descriptor */
-        dma_addr = dma_map_single(
-                        &priv->xdev->pdev->dev,
-                        priv->res,
-                        sizeof(struct xdma_result),
-                        DMA_FROM_DEVICE);
-        priv->rx_desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(dma_addr));
-        priv->rx_desc->src_addr_hi = cpu_to_le32(PCI_DMA_H(dma_addr));
+        priv->rx_desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(priv->res_dma_addr));
+        priv->rx_desc->src_addr_hi = cpu_to_le32(PCI_DMA_H(priv->res_dma_addr));
         rx_desc_set(priv->rx_desc, priv->rx_dma_addr, XDMA_BUFFER_SIZE);
         spin_lock_irqsave(&priv->rx_lock, flag);
         ioread32(&priv->rx_engine->regs->status_rc);

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -17,7 +17,9 @@
 
 static size_t workaround_packet_size(size_t size) {
 #ifdef __LIBXDMA_RPI__
-        if (size >= 94 && ((size - 94) % 128) < 5) {
+        if ((size >= 95 && size <= 99)
+	 || (size >= 222 && size <= 225)
+	 || (size >= 351 && size <= 353)) {
                 return size + WORKAROUND_PAD;
         }
 #endif

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -18,7 +18,7 @@
 static size_t workaround_packet_size(size_t size) {
 #ifdef __LIBXDMA_RPI__
         if (size >= 94 && ((size - 94) % 128) < 5) {
-                return size + WORKAOUND_PAD;
+                return size + WORKAROUND_PAD;
         }
 #endif
         return size;

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -315,7 +315,7 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                 if (++(priv->tstamp_retry[tstamp_id]) >= TX_TSTAMP_MAX_RETRY) {
                         /* TODO: track the number of skipped packets for ethtool stats */
                         pr_err("Failed to get timestamp: timestamp is only partially updated\n");
-			pr_err("%llx %llx %llu\n", now, tx_tstamp, now - tx_tstamp);
+                        pr_err("%llx %llx %llu\n", now, tx_tstamp, now - tx_tstamp);
                         goto return_error;
                 }
                 goto retry;
@@ -331,13 +331,13 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
         return;
 
 return_error:
-	priv->tstamp_retry[tstamp_id] = 0;
-	clear_bit_unlock(tstamp_id, &priv->state);
-	return;
+        priv->tstamp_retry[tstamp_id] = 0;
+        clear_bit_unlock(tstamp_id, &priv->state);
+        return;
 
 retry:
-	schedule_work(&priv->tx_work[tstamp_id]);
-	return;
+        schedule_work(&priv->tx_work[tstamp_id]);
+        return;
 }
 
 #define DEFINE_TX_WORK(n) \

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -17,9 +17,7 @@
 
 static size_t workaround_packet_size(size_t size) {
 #ifdef __LIBXDMA_RPI__
-        if ((size >= 95 && size <= 99)
-	 || (size >= 222 && size <= 225)
-	 || (size >= 351 && size <= 353)) {
+        if (size >= 95 && size <= 99) {
                 return size + WORKAROUND_PAD;
         }
 #endif

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -13,6 +13,17 @@
 #define LOWER_29_BITS ((1ULL << 29) - 1)
 #define TX_WORK_OVERFLOW_MARGIN 100
 
+#define WORKAROUND_PAD 5
+
+static bool is_troubled_size(size_t size) {
+	if ((size >= 95 && size <= 99)
+	 || (size >= 222 && size <= 225)
+	 || (size >= 351 && size <= 353)) {
+		return true;
+	}
+        return false;
+}
+
 static void tx_desc_set(struct xdma_desc *desc, dma_addr_t addr, u32 len)
 {
         u32 control_field;
@@ -102,11 +113,16 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         struct tx_buffer* tx_buffer;
         struct tx_metadata* tx_metadata;
         u32 to_value;
+        bool trouble_flag = false;
 
         /* Check desc count */
         netif_stop_queue(ndev);
         xdma_debug("xdma_netdev_start_xmit(skb->len : %d)\n", skb->len);
         skb->len = max((unsigned int)ETH_ZLEN, skb->len);
+        if (is_troubled_size(skb->len)) {
+                trouble_flag = true;
+                skb->len += WORKAROUND_PAD;
+        }
         if (skb_padto(skb, skb->len)) {
                 pr_err("skb_padto failed\n");
                 netif_wake_queue(ndev);
@@ -123,7 +139,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         }
 
         /* Store packet length */
-        frame_length = skb->len;
+        frame_length = skb->len - (trouble_flag ? WORKAROUND_PAD : 0);
 
         /* Add metadata to the skb */
         if (pskb_expand_head(skb, TX_METADATA_SIZE, 0, GFP_ATOMIC) != 0) {

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -140,7 +140,9 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
 
         /* Add metadata to the skb */
         if (pskb_expand_head(skb, TX_METADATA_SIZE, 0, GFP_ATOMIC) != 0) {
+#ifdef __LIBXDMA_DEBUG__
                 pr_err("pskb_expand_head failed\n");
+#endif
                 netif_wake_queue(ndev);
                 dev_kfree_skb(skb);
                 return NETDEV_TX_OK;

--- a/driver/XDMA/linux-kernel/xdma/xdma_thread.h
+++ b/driver/XDMA/linux-kernel/xdma/xdma_thread.h
@@ -144,4 +144,7 @@ void xdma_thread_remove_work(struct xdma_engine *engine);
  *****************************************************************************/
 void xdma_thread_add_work(struct xdma_engine *engine);
 
+int xdma_kthread_start(struct xdma_kthread *thp, char *name, int id);
+int xdma_kthread_stop(struct xdma_kthread *thp);
+
 #endif /* #ifndef __XDMA_KTHREAD_H__ */

--- a/src/vlan.rs
+++ b/src/vlan.rs
@@ -37,7 +37,7 @@ pub fn setup_tas(ifname: &str, config: &TasConfig) -> Result<i32, String> {
     }
     let cmd = format!(
         "tc qdisc replace dev {} parent root handle {} taprio num_tc {} map{} \
-         queues{} base-time {}{} flags 0x2 txtime_delay {}",
+         queues{} base-time {}{} flags 0x2 txtime-delay {}",
         ifname, handle, num_tc, priomap, queues, base_time, sched_entries, txtime_delay
     );
     run_cmd(&cmd)?;

--- a/src/vlan.rs
+++ b/src/vlan.rs
@@ -36,8 +36,8 @@ pub fn setup_tas(ifname: &str, config: &TasConfig) -> Result<i32, String> {
         sched_entries.push_str(&format!(" sched-entry {}", entry));
     }
     let cmd = format!(
-        "tc qdisc replace dev {} parent root handle {} taprio num_tc {} map{} \
-         queues{} base-time {}{} flags 0x2 txtime-delay {}",
+        "tc qdisc replace dev {} parent root handle {} taprio num_tc {} map {} \
+         queues {} base-time {}{} flags 0x2 txtime-delay {}",
         ifname, handle, num_tc, priomap, queues, base_time, sched_entries, txtime_delay
     );
     run_cmd(&cmd)?;
@@ -66,7 +66,7 @@ pub fn setup_cbs(ifname: &str, config: &CbsConfig) -> Result<i32, String> {
     }
     let cmd = format!(
         "tc qdisc add dev {} parent root handle {} mqprio \
-         num_tc {} map{} queues {}hw 0",
+         num_tc {} map {} queues {} hw 0",
         ifname, root_handle, num_tc, priomap, queues
     );
     run_cmd(&cmd)?;

--- a/src/vlan.rs
+++ b/src/vlan.rs
@@ -36,8 +36,8 @@ pub fn setup_tas(ifname: &str, config: &TasConfig) -> Result<i32, String> {
         sched_entries.push_str(&format!(" sched-entry {}", entry));
     }
     let cmd = format!(
-        "tc qdisc replace dev {} parent root handle {} taprio num_tc {} map {} \
-         queues {} base-time {}{} flags 0x2 txtime-delay {}",
+        "tc qdisc replace dev {} parent root handle {} taprio num_tc {} map{} \
+         queues{} base-time {}{} flags 0x2 txtime_delay {}",
         ifname, handle, num_tc, priomap, queues, base_time, sched_entries, txtime_delay
     );
     run_cmd(&cmd)?;
@@ -66,7 +66,7 @@ pub fn setup_cbs(ifname: &str, config: &CbsConfig) -> Result<i32, String> {
     }
     let cmd = format!(
         "tc qdisc add dev {} parent root handle {} mqprio \
-         num_tc {} map {} queues {} hw 0",
+         num_tc {} map{} queues {}hw 0",
         ifname, root_handle, num_tc, priomap, queues
     );
     run_cmd(&cmd)?;

--- a/src/vlan.rs
+++ b/src/vlan.rs
@@ -65,8 +65,8 @@ pub fn setup_cbs(ifname: &str, config: &CbsConfig) -> Result<i32, String> {
         queues.push_str(&format!("{} ", s));
     }
     let cmd = format!(
-        "tc qdisc add dev {} parent root handle {} mqprio num_tc {} map \
-         {} queues {} hw 0",
+        "tc qdisc add dev {} parent root handle {} mqprio \
+         num_tc {} map{} queues {}hw 0",
         ifname, root_handle, num_tc, priomap, queues
     );
     run_cmd(&cmd)?;


### PR DESCRIPTION
라즈베리 파이 5에서 TSN NIC/HAT이 네트워크 디바이스로서 작동할 수 있도록 합니다.

그 과정에서 발생한 패킷 중복 이슈를 수정했고, ping 진행 중 먹통이 되는 이슈를 임시로 우회하도록 했습니다.

Closing: SW-398, SW-399, SW-401