### PR TITLE
Remove hw timestamp bug workaround

### DIFF
--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -86,6 +86,8 @@ int xdma_netdev_open(struct net_device *ndev)
         iowrite32(DMA_ENGINE_START, &priv->rx_engine->regs->control);
         spin_unlock_irqrestore(&priv->rx_lock, flag);
 
+        printk("driver update message\n"); /* Should be deleted */
+
         return 0;
 }
 
@@ -303,9 +305,9 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                 goto retry;
         }
         /*
-         * Read TX timestamp several times because
-         * 1. Reading and writing TX timestamp register are not atomic
-         * 2. The work thread might try to read TX timestamp before the register gets updated
+         * Read TX timestamp several times because 
+         * the work thread might try to read TX timestamp
+         * before the register gets updated
          */
         tx_tstamp = alinx_read_tx_timestamp(priv->pdev, tstamp_id);
         if (tx_tstamp == priv->last_tx_tstamp[tstamp_id]) {
@@ -325,16 +327,8 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
                         goto return_error;
                 }
                 goto retry;
-        } else if (now - tx_tstamp > TX_TSTAMP_UPDATE_THRESHOLD) {
-                /* Tx timestamp is only partially updated */
-                if (++(priv->tstamp_retry[tstamp_id]) >= TX_TSTAMP_MAX_RETRY) {
-                        /* TODO: track the number of skipped packets for ethtool stats */
-                        pr_err("Failed to get timestamp: timestamp is only partially updated\n");
-                        pr_err("%llx %llx %llu\n", now, tx_tstamp, now - tx_tstamp);
-                        goto return_error;
-                }
-                goto retry;
         }
+
         priv->tstamp_retry[tstamp_id] = 0;
         shhwtstamps.hwtstamp = ns_to_ktime(alinx_sysclock_to_txtstamp(priv->pdev, tx_tstamp));
         priv->last_tx_tstamp[tstamp_id] = tx_tstamp;

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -86,8 +86,6 @@ int xdma_netdev_open(struct net_device *ndev)
         iowrite32(DMA_ENGINE_START, &priv->rx_engine->regs->control);
         spin_unlock_irqrestore(&priv->rx_lock, flag);
 
-        printk("driver update message\n"); /* Should be deleted */
-
         return 0;
 }
 

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -290,15 +290,19 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
         struct skb_shared_hwtstamps shhwtstamps;
         struct xdma_private* priv = container_of(work - tstamp_id, struct xdma_private, tx_work[0]);
         struct sk_buff* skb = priv->tx_work_skb[tstamp_id];
-#ifdef __LIBXDMA_DEBUG__
+        sysclock_t now = alinx_get_sys_clock(priv->xdev->pdev);
+
         if (tstamp_id >= TSN_TIMESTAMP_ID_MAX) {
                 pr_err("Invalid timestamp ID\n");
                 return;
         }
-#endif
+
         if (!priv->tx_work_skb[tstamp_id]) {
-                clear_bit_unlock(tstamp_id, &priv->state);
-                return;
+                goto return_error;
+        }
+
+        if (now < priv->tx_work_start_after[tstamp_id]) {
+                goto retry;
         }
         /*
          * Read TX timestamp several times because 
@@ -327,11 +331,21 @@ static void do_tx_work(struct work_struct *work, u16 tstamp_id) {
 
         priv->tstamp_retry[tstamp_id] = 0;
         shhwtstamps.hwtstamp = ns_to_ktime(alinx_sysclock_to_txtstamp(priv->pdev, tx_tstamp));
+        priv->last_tx_tstamp[tstamp_id] = tx_tstamp;
 
         priv->tx_work_skb[tstamp_id] = NULL;
         clear_bit_unlock(tstamp_id, &priv->state);
         skb_tstamp_tx(skb, &shhwtstamps);
         dev_kfree_skb_any(skb);
+        return;
+
+return_error:
+        priv->tstamp_retry[tstamp_id] = 0;
+        clear_bit_unlock(tstamp_id, &priv->state);
+        return;
+
+retry:
+        schedule_work(&priv->tx_work[tstamp_id]);
         return;
 }
 

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -67,6 +67,8 @@ struct xdma_private {
         sysclock_t tx_work_start_after[TSN_TIMESTAMP_ID_MAX];
         sysclock_t tx_work_wait_until[TSN_TIMESTAMP_ID_MAX];
         struct hwtstamp_config tstamp_config;
+        sysclock_t last_tx_tstamp[TSN_TIMESTAMP_ID_MAX];
+        int tstamp_retry[TSN_TIMESTAMP_ID_MAX];
 
         uint64_t total_tx_count;
         uint64_t total_tx_drop_count;

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -28,15 +28,6 @@
 
 #define TX_TSTAMP_MAX_RETRY 5
 
-/**
- * This value is estimated by experiment.
- * There might be a delay greater than this,
- * or an error less than this.
- * But that's not detectable by SW, until
- * reading Tx timestamp becomes atomic.
- */
-#define TX_TSTAMP_UPDATE_THRESHOLD 0xFFFFF
-
 enum xdma_state_t {
         XDMA_TX1_IN_PROGRESS = 1,
         XDMA_TX2_IN_PROGRESS = 2,


### PR DESCRIPTION
HW timestamp bug has been fixed, thus workaround code is removed

* Remove retrying logic when timestamp is partially updated, since this doesn't(hopefully) happen anymore
* Remove related macro and comments

* "Build / clang_format" was already failing in the origin/main