### PR TITLE
Increase queue count, Fix build error with DEBUG=1 option

### DIFF
--- a/driver/XDMA/linux-kernel/xdma/alinx_arch.h
+++ b/driver/XDMA/linux-kernel/xdma/alinx_arch.h
@@ -35,8 +35,8 @@ typedef uint32_t u32
 #define REG_TO_OVERFLOW_POPPED_COUNT 0x0420
 #define REG_TO_OVERFLOW_TIMEOUT_COUNT 0x0424
 
-#define TX_QUEUE_COUNT 3
-#define RX_QUEUE_COUNT 1
+#define TX_QUEUE_COUNT 8
+#define RX_QUEUE_COUNT 8
 
 /* 125 MHz */
 #define TICKS_SCALE 8.0

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -173,7 +173,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         }
 
         xdma_debug("0x%08x  0x%08x  0x%08x  %4d  %1d",
-                sys_count_low, tx_metadata->from.tick, tx_metadata->to.tick,
+                sys_count_lower, tx_metadata->from.tick, tx_metadata->to.tick,
                 tx_metadata->frame_length, tx_metadata->fail_policy);
         dump_buffer((unsigned char*)tx_metadata, (int)(sizeof(struct tx_metadata) + skb->len));
 

--- a/src/bin/throughput.rs
+++ b/src/bin/throughput.rs
@@ -311,16 +311,11 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
     for _ in 0..3 {
         if let Err(e) = sock.send(eth_pkt.packet()) {
             eprintln!("Failed to send packet: {}", e)
-        } else {
-            eprintln!("debug: Sent ReqStart packet");
         }
 
         match wait_for_response(&mut sock, PerfOpFieldValues::ResStart) {
             Err(_) => eprintln!("No response, retrying..."),
-            Ok(_) => {
-                eprintln!("debug: Received ResStart packet");
-                break;
-            }
+            Ok(_) => break,
         }
     }
 
@@ -337,7 +332,7 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
         }
     });
 
-    // Send data with rate limit
+    // Send data
     println!("Sending data");
     let mut perf_buffer = vec![0; 8 + size];
     let mut eth_buffer = vec![0; 14 + 8 + size];
@@ -348,10 +343,6 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
 
     let now = Instant::now();
     let mut last_id = 0;
-    let target_bps = 500_000_000; // Maximum Bandwidth : 500 Mbps
-    let bits_per_packet = (8 + size + 14) * 8; // Packet size(eth.header + payload) into bits
-    let delay_per_packet = Duration::from_secs_f64(bits_per_packet as f64 / target_bps as f64);
-
     loop {
         let mut perf_pkt = MutablePerfPacket::new(&mut perf_buffer).unwrap();
         perf_pkt.set_id(last_id); // TODO: Randomize
@@ -361,8 +352,6 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
         if sock.send(eth_pkt.packet()).is_err() {}
 
         last_id += 1;
-
-        thread::sleep(delay_per_packet); // Restricting the speed
 
         if now.elapsed().as_secs() > duration as u64 || !unsafe { RUNNING } {
             break;
@@ -387,15 +376,10 @@ fn do_client(iface_name: String, target: String, size: usize, duration: usize) {
     for _ in 0..3 {
         if let Err(e) = sock.send(eth_pkt.packet()) {
             eprintln!("Failed to send packet: {}", e);
-        } else {
-            eprintln!("debug: Sent ReqEnd packet");
         }
 
         match wait_for_response(&mut sock, PerfOpFieldValues::ResEnd) {
-            Ok(_) => {
-                eprintln!("debug: Received ResEnd packet");
-                break;
-            },
+            Ok(_) => break,
             Err(_) => eprintln!("No response, retrying..."),
         }
     }


### PR DESCRIPTION
Throughput issue #60 was caused by HW timestamp bug, thus fixing the HW timestamp bug also fixed the throughput issue

- Increase TX, RX queue count ; to ease QoS setting
- Fix xdma build error with DEBUG=1 option ; `make DEBUG=1`
- "Build / clang_format" was already failing in the origin/main