### PR TITLE
Fix multiqueue handling issues

### DIFF
--- a/driver/XDMA/linux-kernel/xdma/libxdma.c
+++ b/driver/XDMA/linux-kernel/xdma/libxdma.c
@@ -1401,6 +1401,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 {
 	u32 ch_irq;
 	u32 mask;
+	u16 q;
 	int skb_len;
 	unsigned long flag;
 	struct interrupt_regs *irq_regs;
@@ -1507,13 +1508,15 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 
 		engine_status_read(engine, 1, 0);
 
+		q = skb_get_queue_mapping(priv->tx_skb);
+
 		/* Free last resource */
 		dma_unmap_single(&xdev->pdev->dev, priv->tx_dma_addr, priv->tx_skb->len, DMA_TO_DEVICE);
 		dev_kfree_skb_any(priv->tx_skb);
 		priv->tx_skb = NULL;
 
 		iowrite32(DMA_ENGINE_STOP, &engine->regs->control);
-		netif_wake_queue(ndev);
+		netif_wake_subqueue(ndev, q);
 		channel_interrupts_enable(engine->xdev, engine->irq_bitmask);
 	}
 	xdev->irq_count++;

--- a/driver/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -226,6 +226,7 @@ static const struct net_device_ops xdma_netdev_ops = {
 	.ndo_start_xmit = xdma_netdev_start_xmit,
 	.ndo_setup_tc = xdma_netdev_setup_tc,
 	.ndo_eth_ioctl = xdma_netdev_ioctl,
+	.ndo_select_queue = xdma_select_queue,
 };
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -241,6 +241,10 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         return NETDEV_TX_OK;
 }
 
+u16 xdma_select_queue(struct net_device *ndev, struct sk_buff *skb, struct net_device *sb_dev) {
+	return 0;
+}
+
 static LIST_HEAD(xdma_block_cb_list);
 
 static int xdma_setup_tc_block_cb(enum tc_setup_type type, void *type_data, void *cb_priv) {

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -244,7 +244,8 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
 }
 
 u16 xdma_select_queue(struct net_device *ndev, struct sk_buff *skb, struct net_device *sb_dev) {
-	return 0;
+        /* Always use the first subqueue */
+        return 0;
 }
 
 static LIST_HEAD(xdma_block_cb_list);

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -68,6 +68,9 @@ int xdma_netdev_open(struct net_device *ndev)
 
         netif_carrier_on(ndev);
         netif_start_queue(ndev);
+        for (int i = 0; i < TX_QUEUE_COUNT; i++) {
+                netif_start_subqueue(ndev, i);
+        }
 
         /* Set the RX descriptor */
         priv->rx_desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(priv->res_dma_addr));
@@ -94,6 +97,9 @@ int xdma_netdev_close(struct net_device *ndev)
         struct xdma_private *priv = netdev_priv(ndev);
         iowrite32(DMA_ENGINE_STOP, &priv->rx_engine->regs->control);
         netif_stop_queue(ndev);
+        for (int i = 0; i < TX_QUEUE_COUNT; i++) {
+                netif_stop_subqueue(ndev, i);
+        }
         pr_info("xdma_netdev_close\n");
         netif_carrier_off(ndev);
         pr_info("netif_carrier_off\n");
@@ -113,9 +119,12 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         struct tx_buffer* tx_buffer;
         struct tx_metadata* tx_metadata;
         u32 to_value;
+        u16 q;
+
 
         /* Check desc count */
-        netif_stop_queue(ndev);
+        q = skb_get_queue_mapping(skb);
+        netif_stop_subqueue(ndev, q);
         xdma_debug("xdma_netdev_start_xmit(skb->len : %d)\n", skb->len);
         skb->len = max((unsigned int)ETH_ZLEN, skb->len);
 
@@ -125,7 +134,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
 
         if (skb_padto(skb, skb->len)) {
                 pr_err("skb_padto failed\n");
-                netif_wake_queue(ndev);
+                netif_wake_subqueue(ndev, q);
                 dev_kfree_skb(skb);
                 return NETDEV_TX_OK;
         }
@@ -133,7 +142,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         /* Jumbo frames not supported */
         if (skb->len > XDMA_BUFFER_SIZE) {
                 pr_err("Jumbo frames not supported\n");
-                netif_wake_queue(ndev);
+                netif_wake_subqueue(ndev, q);
                 dev_kfree_skb(skb);
                 return NETDEV_TX_OK;
         }
@@ -143,7 +152,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
 #ifdef __LIBXDMA_DEBUG__
                 pr_err("pskb_expand_head failed\n");
 #endif
-                netif_wake_queue(ndev);
+                netif_wake_subqueue(ndev, q);
                 dev_kfree_skb(skb);
                 return NETDEV_TX_OK;
         }
@@ -168,7 +177,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
 #ifdef __LIBXDMA_DEBUG__
                 pr_warn("tsn_fill_metadata failed\n");
 #endif
-                netif_wake_queue(ndev);
+                netif_wake_subqueue(ndev, q);
                 return NETDEV_TX_BUSY;
         }
 
@@ -180,7 +189,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
         dma_addr = dma_map_single(&xdev->pdev->dev, skb->data, skb->len, DMA_TO_DEVICE);
         if (unlikely(dma_mapping_error(&xdev->pdev->dev, dma_addr))) {
                 pr_err("dma_map_single failed\n");
-                netif_wake_queue(ndev);
+                netif_wake_subqueue(ndev, q);
                 return NETDEV_TX_BUSY;
         }
 

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.c
@@ -65,10 +65,11 @@ int xdma_netdev_open(struct net_device *ndev)
         struct xdma_private *priv = netdev_priv(ndev);
         u32 lo, hi;
         unsigned long flag;
+        int i;
 
         netif_carrier_on(ndev);
         netif_start_queue(ndev);
-        for (int i = 0; i < TX_QUEUE_COUNT; i++) {
+        for (i = 0; i < TX_QUEUE_COUNT; i++) {
                 netif_start_subqueue(ndev, i);
         }
 
@@ -94,10 +95,11 @@ int xdma_netdev_open(struct net_device *ndev)
 
 int xdma_netdev_close(struct net_device *ndev)
 {
+        int i;
         struct xdma_private *priv = netdev_priv(ndev);
         iowrite32(DMA_ENGINE_STOP, &priv->rx_engine->regs->control);
         netif_stop_queue(ndev);
-        for (int i = 0; i < TX_QUEUE_COUNT; i++) {
+        for (i = 0; i < TX_QUEUE_COUNT; i++) {
                 netif_stop_subqueue(ndev, i);
         }
         pr_info("xdma_netdev_close\n");

--- a/driver/XDMA/linux-kernel/xdma/xdma_netdev.h
+++ b/driver/XDMA/linux-kernel/xdma/xdma_netdev.h
@@ -161,6 +161,7 @@ netdev_tx_t xdma_netdev_start_xmit(struct sk_buff *skb,
 int xdma_netdev_setup_tc(struct net_device *ndev, enum tc_setup_type type, void *type_data);
 
 int xdma_netdev_ioctl(struct net_device *ndev, struct ifreq *ifr, int cmd);
+u16 xdma_select_queue(struct net_device *ndev, struct sk_buff *skb, struct net_device *sb_dev);
 
 void xdma_tx_work1(struct work_struct *work);
 void xdma_tx_work2(struct work_struct *work);


### PR DESCRIPTION
Tx/Rx 큐를 여러 개 설정했을 때 발생하는 이슈들을 수정합니다.

네트워크 큐를 시작하고 멈출 때 subqueue를 사용하도록 수정했으며, 항상 0번 subqueue를 사용하도록 했습니다.
subqueue를 강제로 지정하더라도 tc 명령어에 영향을 주지 않는 것으로 확인되었습니다.

현재 테스트 진행 중이며, 다른 이상이 발견될 경우 추가로 수정하도록 하겠습니다.

Closing: SW-507, SW-508, SW-509